### PR TITLE
fix: avoid running dotnet test on benchmark project

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,4 +37,4 @@ jobs:
     - name: Build
       run: dotnet build -c ${{ matrix.configuration }} --no-restore -p:NoWarn=CS1591
     - name: Test
-      run: dotnet test -c ${{ matrix.configuration }} --no-build --no-restore --verbosity normal
+      run: dotnet test src/FastGenericNew.Tests/FastGenericNew.Tests.csproj -c ${{ matrix.configuration }} --no-build --no-restore --verbosity normal


### PR DESCRIPTION
## Summary
- run `dotnet test` against `src/FastGenericNew.Tests/FastGenericNew.Tests.csproj`
- avoid invoking VSTest on `FastGenericNew.Benchmarks`
- fixes the CI failure seen in #103 after the NUnit3TestAdapter 6.2.0 bump

## Why
The workflow currently tests the whole solution. With the adapter bump, the benchmark project gets included in the VSTest phase and emits framework compatibility warnings that cause the Ubuntu Release check to fail even though the real test project passes.

Related to #103
