### PR TITLE
fix: revert NUnit3TestAdapter to 4.6.0

### DIFF
--- a/src/FastGenericNew.Tests/FastGenericNew.Tests.csproj
+++ b/src/FastGenericNew.Tests/FastGenericNew.Tests.csproj
@@ -22,7 +22,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="NUnit" Version="4.6.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
 		<PackageReference Include="coverlet.collector" Version="10.0.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- revert `NUnit3TestAdapter` from `6.2.0` back to `4.6.0`
- keep the workflow fix from #106 intact

## Root cause
After both #103 and #106 were merged, CI on `main` started failing in the test step with:

`An exception occurred while invoking executor 'executor://nunit3testexecutor/': Could not load type 'System.Runtime.Remoting.Channels.IChannel' ...`

This is coming from the adapter bump in #103, not from the workflow-scoping fix in #106.

## Why this PR
- #106 fixed the original workflow bug (solution-level `dotnet test` touching non-test projects)
- but `NUnit3TestAdapter 6.2.0` still breaks test execution on `main`
- reverting the adapter restores the last known working adapter version while preserving the workflow fix

## Evidence
- failing push run on `main`: `25412564931`
- failing job: `74537289531`
- error line: `Could not load type 'System.Runtime.Remoting.Channels.IChannel'`
